### PR TITLE
Add fix for repeating datetime

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,16 +31,15 @@ prev_text = '';
 // reconnected listening
 webSocket.listen(function(message) {
 
-	/* enable this to view Array of data in the console.
-		if (message['acn'] != "vid") {
-			console.log(message);
-		}
-	*/
+	// /* enable this to view Array of data in the console.
+	// if (message['acn'] != "vid") {
+	// 	console.log(message);
+	// }
 	
 	// only parse fv arrays
 	if (message['acn'] == "fv") {
 		if (message['ary'][0]['txt'] != undefined && message['ary'][0]['acn'] === 'cs') {
-			var text = '';
+		var text = '';
 			
 			// check slide note for noText keyword.  If noText is defined dont step into this IF
 			if (typeof message['ary'][2] !== 'undefined' && message['ary'][2]['txt'] !== config["noText"]) {

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ webSocket.listen(function(message) {
 	// only parse fv arrays
 	if (message['acn'] == "fv") {
 		if (message['ary'][0]['txt'] != undefined && message['ary'][0]['acn'] === 'cs') {
-		var text = '';
+			var text = '';
 			
 			// check slide note for noText keyword.  If noText is defined dont step into this IF
 			if (typeof message['ary'][2] !== 'undefined' && message['ary'][2]['txt'] !== config["noText"]) {

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ webSocket.listen(function(message) {
 	
 	// only parse fv arrays
 	if (message['acn'] == "fv") {
-		if (message['ary'][0]['txt'] != undefined) {
+		if (message['ary'][0]['txt'] != undefined && message['ary'][0]['acn'] === 'cs') {
 			var text = '';
 			
 			// check slide note for noText keyword.  If noText is defined dont step into this IF


### PR DESCRIPTION
In ProPresenter 6 in Windows we were having an issue where the slide would show for a second and then the date would just keep getting sent. This adds a check for the current slide. I tested against PP6 and PP7 in Windows and it seems to be working. 