### PR TITLE
Allow host name to be specified instead of IP address

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -4,6 +4,7 @@ var config = {
 	//Enable under ProPresenter Preferences -> Network tab
 	//Enable Network and Stage Display App
 	'propresenter_ip' : '192.168.1.4',
+        //or instead of the above use  'propresenter_hostname': 'computername.local',
 	'propresenter_port' : 60157, //port from Network NOT Stage Display App
 	'propresenter_password' : 'av', //password from Stage Display App
 	'fade' : true,

--- a/index.html
+++ b/index.html
@@ -57,7 +57,12 @@ function processProPresenterMessage(message) {
 
 
 function connectToProPresenter() {
-    var proPresenterStageDisplayURL = 'ws://' + config['propresenter_ip'] + ':' + config['propresenter_port'] + '/stagedisplay';
+    var proPresenterStageDisplayURL;
+    if ('propresenter_hostname' in config) {
+        proPresenterStageDisplayURL = 'ws://' + config['propresenter_hostname'] + ':' + config['propresenter_port'] + '/stagedisplay';
+    } else {
+        proPresenterStageDisplayURL = 'ws://' + config['propresenter_ip'] + ':' + config['propresenter_port'] + '/stagedisplay';
+    }
     
     var ws = new WebSocket(proPresenterStageDisplayURL);
 


### PR DESCRIPTION
We use the same machines on different networks, which means IP addresses are different. This change allows the computer name to be specified instead of IP address, e.g. 'katies-macbook-pro.local'.